### PR TITLE
Add XATTR request and data encoding details

### DIFF
--- a/documentation/commands/deletion.md
+++ b/documentation/commands/deletion.md
@@ -75,6 +75,21 @@ The client should not send a reply to this command. The following example shows 
 
 This message will not return a response unless an error occurs.
 
+###Extended Attributes (XATTRs)
+
+If a Document has XATTRs and `DCP_OPEN_INCLUDE_XATTRS` was set as part
+of the [DCP_OPEN](open-connection.md) message, then the `DCP_MUTATION`
+message will include the XATTRs as part of the Value payload.
+
+The presence of XATTRs is indicated by setting the XATTR bit in the
+datatype field:
+
+    #define PROTOCOL_BINARY_DATATYPE_XATTR uint8_t(4)
+
+See
+[Document - Extended Attributes](https://github.com/couchbase/memcached/blob/master/docs/Document.md#xattr---extended-attributes)
+for details of the encoding scheme.
+
 ###Extended Meta Data Section
 The extended meta data section is used to send extra meta data for a particular deletion. This section is at the very end, after the value. Its length will be set in the nmeta field.
 * [**Ext_Meta**](extended_meta/ext_meta_ver1.md)

--- a/documentation/commands/mutation.md
+++ b/documentation/commands/mutation.md
@@ -99,6 +99,21 @@ The consumer should not send a reply to this command. The following example show
 
 This message will not return a response unless an error occurs.
 
+###Extended Attributes (XATTRs)
+
+If a Document has XATTRs and `DCP_OPEN_INCLUDE_XATTRS` was set as part
+of the [DCP_OPEN](open-connection.md) message, then the `DCP_MUTATION`
+message will include the XATTRs as part of the Value payload.
+
+The presence of XATTRs is indicated by setting the XATTR bit in the
+datatype field:
+
+    #define PROTOCOL_BINARY_DATATYPE_XATTR uint8_t(4)
+
+See
+[Document - Extended Attributes](https://github.com/couchbase/memcached/blob/master/docs/Document.md#xattr---extended-attributes)
+for details of the encoding scheme.
+
 ###Extended Meta Data Section
 The extended meta data section is used to send extra meta data for a particular mutation. This section is at the very end, after the value. Its length will be set in the nmeta field.
 * [**Ext_Meta**](extended_meta/ext_meta_ver1.md)

--- a/documentation/commands/open-connection.md
+++ b/documentation/commands/open-connection.md
@@ -21,7 +21,10 @@ Extra looks like:
 
 Flags are specified as a bitmask in network byte order with the following bits defined:
 
-     1 - Type: Producer (bit set) / Consumer (bit cleared).
+     0x1 - Type: Producer (bit set) / Consumer (bit cleared).
+     0x2 - Type: Notifier (bit set). Note: both bits 1 and 2 should NOT be set.
+     0x4 - Include XATTRs. Specifies that DCP_MUTATION and DCP_DELETION messages
+           should include any XATTRs associated with the Document.
 
 When setting the Producer or Consumer flag the sender is telling the server what type of connection will be created. For example, if the Producer type is set then the sender of the Open Connection message will be a Consumer.
 


### PR DESCRIPTION
Document the DCP_OPEN flag INCLUDE_XATTRs to request XATTRs are
included in DCP mutations and deletions.

Document the encoding of the XATTRs in the value field.