### PR TITLE
Fix markdown headers   

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#DCP Documentation
+# DCP Documentation
 
 The Database Change Protocol (DCP) a protocol used by Couchbase for moving large amounts of data. The protocol intended for use in replication, indexing, and third-patry integrations where moving a lot of data quickly and efficiently is necessary.
 

--- a/documentation/building-a-simple-client.md
+++ b/documentation/building-a-simple-client.md
@@ -1,8 +1,8 @@
-#Building a Simple Client
+# Building a Simple Client
 
 In order to begin using DCP we first need a client capable of understanding the DCP protocol so that we can being streaming information. This page describes how to create a simple DCP client that will be able to connection to a single node Couchbase cluster and stream data. We will assume that the our single node cluster never crashes and that the client has no need for enabling any special mechanisms such as [flow control](flow-control.md) or [dead connection detection](dead-connections.md).
 
-###DCP Is A Full Duplex Protocol
+### DCP Is A Full Duplex Protocol
 
 Responses for certain client requests can be received out of order and clients are required to inspect the opaque field of a DCP response in order to match it to a request. As a result client applications need to be able to read and write to a socket at the same time.
 
@@ -15,11 +15,11 @@ In order to support a full duplex connection clients can for example be implemen
 
 Note that there are other ways to implement a full duplex connection and the list above is meant to be examples for how to accomplish this. Also keep in mind that clients should not be creating a lot of connections. As a result developers should not worry about choosing mechanisms known to scale the number of connections your client can handle.
 
-###Creating a connection
+### Creating a connection
 
 Once your client networking code is in place the next step is to verify that your client can create and close a DCP connection. Creating a connection simply involves sending an [Open Connection](commands/open-connection.md) message which simply names the connection. After your client sends the [Open Connection](open-connection.md) message the client should check to make sure the connection was successfully created on the server. If it was you should be able to request dcp stats from the server and see your connection stats listed in the stats output. This connection will remain open until your client closes its socket. If the connection closes unexpectedly then this means something unexpected happened and the logs should be inspected since an error is always logged if a connection is closed unexpectedly.
 
-###Creating a stream
+### Creating a stream
 
 Once you have a connection established with the server then the next thing to do is to open a stream to the server to stream out data for a specific VBucket. For a basic client the simplest thing to do is to always stream data starting with the first mutation that was received in the VBucket. To do this the Consumer should send [Stream Request](commands/stream-request.md) messages for each VBucket that it wants to recieve data for.
 
@@ -32,7 +32,7 @@ Once you have a connection established with the server then the next thing to do
 * Snapshot End Seqno - Since we that are starting to recieve data for the first time 0 should be specified.
 
 
-###Client Side State
+### Client Side State
 
 DCP achieves restartability of DCP streams through the use of a failover log and sequence number.
 
@@ -41,8 +41,8 @@ DCP achieves restartability of DCP streams through the use of a failover log and
 * Last Snapshot Start Seqno
 * Last Snapshot End Seqno
 
-###Restarting from where you left off
+### Restarting from where you left off
 
 
-###Handling a rollback
+### Handling a rollback
 

--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -1,20 +1,20 @@
-#Change Log
+# Change Log
 
 The purpose of this document is to track major changes that have taken place within DCP on a per release basis.
 
-##3.0
+## 3.0
 
 The 3.0 release was the first release to feature DCP in Couchbase. This release contained support for the entire DCP protocol and supported intra-cluster replication, view engine indexing, cross-datacenter replication, and the incremental backup tool.
 
-##3.0.1
+## 3.0.1
 
 This was a minor bug fix release and contained no major DCP changes.
 
-##3.0.2 (Unreleased)
+## 3.0.2 (Unreleased)
 
 This was a minor bug fix release and contained no major DCP changes.
 
-##3.1.0 (Unreleased)
+## 3.1.0 (Unreleased)
 
 **Parallel Backfills**
 

--- a/documentation/commands/add-stream.md
+++ b/documentation/commands/add-stream.md
@@ -1,4 +1,4 @@
-#Add Stream (opcode 0x51)
+# Add Stream (opcode 0x51)
 
 Sent to the consumer to tell the consumer to initiate a stream request with the producer.
 
@@ -96,11 +96,11 @@ opaque value used by messages passing for that vbucket. The vbucket
 identifier in the extra field is the vbucket identifier this response
 belongs to.
 
-###Returns
+### Returns
 
 On success a unique identifier is returned in the opaque field. This identifier can be used to differentitate two different streams that were accessing the same vbucket. On failure an error code will be returned.
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_EEXISTS (0x02)**
 

--- a/documentation/commands/buffer-ack.md
+++ b/documentation/commands/buffer-ack.md
@@ -1,4 +1,4 @@
-#Buffer Acknowledgement (opcode 0x5d)
+# Buffer Acknowledgement (opcode 0x5d)
 
 Sent to by the Consumer to the Producer in order to inform the Producer that the Consumer has consumed some or all of the data the the Producer has sent and that the Consumer is ready for more data.
 Note: In the acknowledgement we account for both data bytes and message header bytes.
@@ -18,7 +18,7 @@ Extra looks like:
 
 The extras section will contain a 32-bit value which denotes the amount of bytes that the Consumer has processed and indicates to the Producer that the Consumer is capable of receiving more data.
 
-####Binary Implementation
+#### Binary Implementation
 
     Buffer Acknowledgement Binary Request
 
@@ -87,11 +87,11 @@ The extras section will contain a 32-bit value which denotes the amount of bytes
     Opaque       (12-15): 0x00000005          (5)
     CAS          (16-23): 0x0000000000000000  (field not used)
 
-#####Returns
+##### Returns
 
 Whether or not the operation has succeeded
 
-#####Errors
+##### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 

--- a/documentation/commands/close-stream.md
+++ b/documentation/commands/close-stream.md
@@ -1,4 +1,4 @@
-###Close Stream (opcode 0x52)
+### Close Stream (opcode 0x52)
 
 Sent to server controling an DCP stream to close the stream for a named vbucket as soon as possible.
 
@@ -41,11 +41,11 @@ If received on the consumer side the consumer will close the stream for the spec
 
 If received on the producer side the producer will send an end stream message to the consumer indicating that the stream was closed by force. The producer may still receive response messages from the consumer for this stream.
 
-###Returns
+### Returns
 
 A status code indicating whether or not the operation was successful.
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 

--- a/documentation/commands/control.md
+++ b/documentation/commands/control.md
@@ -1,4 +1,4 @@
-#Control (opcode 0x5E)
+# Control (opcode 0x5E)
 
 Sent by the Consumer to the Producer in order to configure connection settings.
 
@@ -94,11 +94,11 @@ The producer will respond immediately with a message indicating whether or not t
     Opaque       (12-15): 0x00000001
     CAS          (16-23): 0x0000000000000000
 
-###Returns
+### Returns
 
 A status code indicating whether or not the operation was successful.
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_EINVAL (0x04)**
 

--- a/documentation/commands/deletion.md
+++ b/documentation/commands/deletion.md
@@ -1,4 +1,4 @@
-###Deletion (0x58)
+### Deletion (0x58)
 
 Tells the consumer that the message contains a key deletion.
 
@@ -71,11 +71,11 @@ The client should not send a reply to this command. The following example shows 
       nmeta      (40-41): 0x0000
     Key          (42-46): hello
 
-###Returns
+### Returns
 
 This message will not return a response unless an error occurs.
 
-###Extended Attributes (XATTRs)
+### Extended Attributes (XATTRs)
 
 If a Document has XATTRs and `DCP_OPEN_INCLUDE_XATTRS` was set as part
 of the [DCP_OPEN](open-connection.md) message, then the `DCP_MUTATION`
@@ -90,11 +90,11 @@ See
 [Document - Extended Attributes](https://github.com/couchbase/memcached/blob/master/docs/Document.md#xattr---extended-attributes)
 for details of the encoding scheme.
 
-###Extended Meta Data Section
+### Extended Meta Data Section
 The extended meta data section is used to send extra meta data for a particular deletion. This section is at the very end, after the value. Its length will be set in the nmeta field.
 * [**Ext_Meta**](extended_meta/ext_meta_ver1.md)
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 

--- a/documentation/commands/expiration.md
+++ b/documentation/commands/expiration.md
@@ -1,4 +1,4 @@
-###Expiration (0x59)
+### Expiration (0x59)
 
 Tells the consumer that the message contains a key expiration.
 
@@ -71,15 +71,15 @@ The client should not send a reply to this command. The following example shows 
       nmeta      (40-41): 0x0000
     Key          (42-46): hello
 
-###Returns
+### Returns
 
 This message will not return a response unless an error occurs.
 
-###Extended Meta Data Section
+### Extended Meta Data Section
 The extended meta data section is used to send extra meta data for a particular expiration. This section is at the very end, after the value. Its length will be set in the nmeta field.
 * [**Ext_Meta**](extended_meta/ext_meta_ver1.md)
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 

--- a/documentation/commands/extended_meta/ext_meta_ver1.md
+++ b/documentation/commands/extended_meta/ext_meta_ver1.md
@@ -1,8 +1,8 @@
-###Extended meta data section v4.0
+### Extended meta data section v4.0
 
 The extended meta data section will be used to send extra meta data for each mutation, deletion or expiration. This section comes at the very end of the message right after the value section. The nmeta field in the packet will contain the length of this field.
 
-####Version 1 (0x01)
+#### Version 1 (0x01)
 
 In this version, the extended meta data section will have the following format:
 
@@ -19,7 +19,7 @@ Here:
 * 0x01 - adjusted time
 * 0x02 - conflict resolution mode
 
-####Operation
+#### Operation
 
 * For the extended meta data to be carried in a message (mutation/deletion/expiration), a control message will need to be sent for key "enable_ext_metadata" by the consumer to the producer after making the connection.
 * The value for enable_ext_metadata needs to be set to true.

--- a/documentation/commands/failover-log.md
+++ b/documentation/commands/failover-log.md
@@ -1,4 +1,4 @@
-###Failover Log Request (opcode 0x54)
+### Failover Log Request (opcode 0x54)
 
 The Failover log request is used by the consumer to request all known failover ids a client may use to continue from. A failover id consists of the vbucket UUID and a sequence number. If a client can't find a known failover id, it should select the vbucket with the highest sequence number since that is the stream with the shortest path to completion.
 
@@ -112,11 +112,11 @@ If the command executes successful (see the status field), the following packet 
       vb UUID    (72-79): 0x00000000deadbeef
       vb seqno   (80-87): 0x0000000000006524
 
-###Returns
+### Returns
 
 A failover log for the vbucket requested. The failover log will be in descending order of time meaning the oldest failover entry will be the last entry in the response and the newest entry will be the first entry in the response. On failure and error code is returned.
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_EINVAL (0x04)**
 

--- a/documentation/commands/flush.md
+++ b/documentation/commands/flush.md
@@ -1,4 +1,4 @@
-###Flush (0x5a) (Not Supported in 3.0)
+### Flush (0x5a) (Not Supported in 3.0)
 
 Tells the consumer to delete all of its data for a given vbucket.
 
@@ -37,11 +37,11 @@ The client should not send a reply to this command. The following example shows 
     Opaque       (12-15): 0xdeadbeef
     CAS          (16-23): 0x0000000000000000
 
-###Returns
+### Returns
 
 This message will not return a response unless an error occurs.
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 

--- a/documentation/commands/mutation.md
+++ b/documentation/commands/mutation.md
@@ -1,4 +1,4 @@
-###Mutation (0x57)
+### Mutation (0x57)
 
 Tells the consumer that the message contains a key mutation.
 
@@ -95,11 +95,11 @@ The consumer should not send a reply to this command. The following example show
     Key          (55-59): hello
     Value        (60-64): world
 
-###Returns
+### Returns
 
 This message will not return a response unless an error occurs.
 
-###Extended Attributes (XATTRs)
+### Extended Attributes (XATTRs)
 
 If a Document has XATTRs and `DCP_OPEN_INCLUDE_XATTRS` was set as part
 of the [DCP_OPEN](open-connection.md) message, then the `DCP_MUTATION`
@@ -114,11 +114,11 @@ See
 [Document - Extended Attributes](https://github.com/couchbase/memcached/blob/master/docs/Document.md#xattr---extended-attributes)
 for details of the encoding scheme.
 
-###Extended Meta Data Section
+### Extended Meta Data Section
 The extended meta data section is used to send extra meta data for a particular mutation. This section is at the very end, after the value. Its length will be set in the nmeta field.
 * [**Ext_Meta**](extended_meta/ext_meta_ver1.md)
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 

--- a/documentation/commands/no-op.md
+++ b/documentation/commands/no-op.md
@@ -1,8 +1,8 @@
-#No-Op (opcode 0x5c)
+# No-Op (opcode 0x5c)
 
 A No-Op message is sent by the Producer to the Consumer if the Producer has not sent any messages for a given interval of time. This interval is referred to as the *"noop interval"*. Upon receiving this message the Consumer is expected to respond with a No-Op response. When the Producer sends the No-Op it starts a timer and expects to see a No-Op response from the Consumer in a period equal to the *"noop interval"*. If no response is seen during this period then the Producer will disconnect. The Consumer should similarly expect to see some sort of message or a No-Op message in a period equal to twice the *"noop interval"* otherwise it should close its connection. See the page on [Dead Connection Detection](../dead-connections.md) for more details.
 
-####Binary Implementation
+#### Binary Implementation
 
     Dcp No-Op Binary Request
 
@@ -70,11 +70,11 @@ A No-Op message is sent by the Producer to the Consumer if the Producer has not 
     Opaque       (12-15): 0x00000005          (5)
     CAS          (16-23): 0x0000000000000000  (field not used)
 
-###Returns
+### Returns
 
 Whether or not the operation has succeeded
 
-###Errors
+### Errors
 
 **(Disconnect)**
 

--- a/documentation/commands/open-connection.md
+++ b/documentation/commands/open-connection.md
@@ -1,4 +1,4 @@
-#Open Connection (opcode 0x50)
+# Open Connection (opcode 0x50)
 
 Sent by an external entity to a producer or a consumer to create a logical channel.
 
@@ -115,11 +115,11 @@ Upon success, the following message is returned.
 
 **Note:** If the name given in the open connection command is already being used by another established connection then the established connection will be closed and the new connection will be created successfully.
 
-###Returns
+### Returns
 
 A status code indicating whether or not the operation was successful.
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_EINVAL (0x04)**
 

--- a/documentation/commands/persist_seqno.md
+++ b/documentation/commands/persist_seqno.md
@@ -1,9 +1,9 @@
 
-##Persist Sequence Number
+## Persist Sequence Number
 
 The Persist Sequence Number command can be used to figure out when an item with a specific Sequence Number/VBucket UUID pair for a given VBucket is persisted into Couchbase.
 
-####Binary Implementation
+#### Binary Implementation
 
     Persist Sequence Number Binary Request
 
@@ -79,17 +79,17 @@ The Persist Sequence Number command can be used to figure out when an item with 
     Opaque       (12-15): 0x00000000
     CAS          (16-23): 0x0000000000000000  (Field not used)
 
-#####Extra Fields
+##### Extra Fields
 
 **Seqno**
 
 Each item in Couchbase is assigned a monotinically increasing Sequence Number. This field should contain the sequence number of the item you want to have persisted. Note that all items with a sequence number below this one will be persisted as well.
 
-#####Returns
+##### Returns
 
 A status code indicating whether or not the operation was successful
 
-#####Errors
+##### Errors
 
 **PROTOCOL_BINARY_RESPONSE_EINVAL (0x04)**
 
@@ -103,7 +103,7 @@ If the consumer does not have the given VBucket then this error is returned.
 
 If the operation does not complete within a certain amount of time this error code indicates a timeout.
 
-#####Use Cases
+##### Use Cases
 
 The Persist Sequence Number command can be used in order to make sure that all up to a specified sequence number have been persisted to disk. This is useful when doing a rebalance ince before moving to the next VBucket we need to make sure that all items have been durable replicated to another node.
 

--- a/documentation/commands/random_key.md
+++ b/documentation/commands/random_key.md
@@ -1,9 +1,9 @@
 
-##Random Key
+## Random Key
 
 The random key command is used to get a single random key from the cache. It is an internal API and is used by the cluster manager in order to help users visualize what there keys look like when writing view code.
 
-####Binary Implementation
+#### Binary Implementation
 
     Random Key Binary Request
 
@@ -74,11 +74,11 @@ The random key command is used to get a single random key from the cache. It is 
     CAS          (16-23): 0x0000000000000000  (field not used)
 	Key          (24-31): "rand_key"
 
-#####Returns
+##### Returns
 
 A random key and value
 
-#####Errors
+##### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 
@@ -88,7 +88,7 @@ If the server doesn't contain any keys.
 
 If data in this packet is malformed or incomplete then this error is returned. This error is also returned if the stream name specified in the packet does not exist.
 
-#####Use Cases
+##### Use Cases
 
 Used to get a random key and value in order to help inspect the data format contained in the server.
 

--- a/documentation/commands/set-vbucket-state.md
+++ b/documentation/commands/set-vbucket-state.md
@@ -1,4 +1,4 @@
-###Set VBucket State (0x5b)
+### Set VBucket State (0x5b)
 
 The Set VBucket message is used during the VBucket takeover process to hand off ownership of a VBucket between two nodes. The message format as well as the state values for this operation is below.
 
@@ -58,11 +58,11 @@ The client should not send a reply to this command. The following example shows 
     CAS          (16-23): 0x0000000000000000
       state      (24)   : 0x4 (dead)
 
-###Returns
+### Returns
 
 Returns success if the vbucket state is successfully changed or returns an error on failure.
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 

--- a/documentation/commands/snapshot-marker.md
+++ b/documentation/commands/snapshot-marker.md
@@ -1,4 +1,4 @@
-###Snapshot Marker (opcode 0x56)
+### Snapshot Marker (opcode 0x56)
 
 Sent by the producer to tell the consumer that a new snapshot is being sent. A snaphot is simply a series of commands that is guarenteed to contain a unique set of keys.
 
@@ -59,11 +59,11 @@ Snapshot Type is defined as:
 * 0x08 (ack) - Specifies that this snapshot marker should return a response once the entire snapshot is received.
 
 
-###Returns
+### Returns
 
 This message will not return a response unless an error occurs or the ack flag is set.
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 

--- a/documentation/commands/stats-vbucket-seqno.md
+++ b/documentation/commands/stats-vbucket-seqno.md
@@ -1,12 +1,12 @@
-##Stats VBucket-Seqno
+## Stats VBucket-Seqno
 
 The Stats VBucket-Seqno command is used to obtain the current High Sequence Number/VBucket UUID for one or all VBuckets on a Couchbase node.
 
-####Binary Implementation
+#### Binary Implementation
 
 See the stats command for details on the packet format for stats commands. Stats VBucket-Seqno can be used by placing the string `vbucket-seqno` into the key section of a stats packet to receive High Sequence Number/VBucket UUID pairs for all VBuckets on a given node. To receive a the High Sequence NUmber/VBucket UUID pair for a single VBucket then you can set the key in the stats command to `vbucket-seqno <vbid>`.
 
-#####Returns
+##### Returns
 
 The stats response from a Stats VBucket-Seqno command will look as follows:
 
@@ -18,7 +18,7 @@ The stats response from a Stats VBucket-Seqno command will look as follows:
     vb_2:vb_uuid 4560392056902
     ...
 
-#####Errors
+##### Errors
 
 **PROTOCOL_BINARY_RESPONSE_EINVAL (0x04)**
 
@@ -28,7 +28,7 @@ If data in this packet is malformed or incomplete then this error is returned.
 
 If you specified a specific VBucket and that VBucket does not exist.
 
-#####Use Cases
+##### Use Cases
 
 This command is typically used before creating an UPR stream in order to find out what the sequence number is of the last mutation the server has for a given VBucket at the time the Stats VBucket-Seqno command was received.
 

--- a/documentation/commands/stream-end.md
+++ b/documentation/commands/stream-end.md
@@ -1,4 +1,4 @@
-###Stream End (opcode 0x55)
+### Stream End (opcode 0x55)
 
 Sent to the consumer to indicate that the producer has no more messages to stream for the specified vbucket.
 
@@ -49,11 +49,11 @@ The flags field is used to specify to the consumer why the stream was closed and
 * *Disconnected (0x03)* - The stream is closing because the connection is being disconnected.
 * *Too Slow (0x04)* - The stream is closing because the client cannot read from the stream fast enough. This is done to prevent the server from running out of resources trying while trying to serve the client. When the client is ready to read from the stream again it should reconnect. This flag is available starting in Couchbase 4.5.
 
-###Returns
+### Returns
 
 A status code indicating whether or not the operation was successful.
 
-###Errors
+### Errors
 
 **PROTOCOL_BINARY_RESPONSE_KEY_ENOENT (0x01)**
 

--- a/documentation/commands/stream-request.md
+++ b/documentation/commands/stream-request.md
@@ -1,4 +1,4 @@
-###Stream Request (opcode 0x53)
+### Stream Request (opcode 0x53)
 
 Sent by the consumer side to the producer specifying that the consumer wants to create a vbucket stream. In order to initial a stream for a vbucket the consumer must send the following command below. In order to initiate multiple stream the consumer needs to send multiple commands. The value specified in opaque in the stream request packet will be used as opaque field in all commands sent for the stream.
 
@@ -271,11 +271,11 @@ The following example tries to initiate a stream for vbucket 0 that continues fr
       vb UUID    (72-79): 0x00000000deadbeef
       vb seqno   (80-87): 0x0000000000006524
 
-###Returns
+### Returns
 
 A status code indicating whether or not the operation was successful.
 
-###Error codes
+### Error codes
 
 **PROTOCOL_BINARY_RESPONSE_KEY_EEXISTS (0x02)**
 

--- a/documentation/concepts.md
+++ b/documentation/concepts.md
@@ -1,19 +1,19 @@
-#Concepts
+# Concepts
 
 DCP is build on four major architectural concepts that allow the protocol to be used to build a rich set of applications. Below are the major concepts.
 
-###Order
+### Order
 
 The first major concept is order and it is the foundation for the rest of the major architectural concepts. Order is important because it allow applications to reason about causality of data or in other words allows an application to know if an operation occurred before or after another operation. DCP achieves order through the use of sequence numbers and failover logs. Sequence numbers are used to keep order on a single node and failover logs are used to resolve ording conflicts during failure scenarios.
 
-###Restartability
+### Restartability
 
 Restartability is an important feature for any replication protocol that often has to deal with large amounts of data. In any distributed system components crash and when your moving large portions of data applications want to be able to resume from exactly where they left off and not have to resend any data in the case of a dropped connection. Due to the DCPs ordering mechanism restartability is possible from any point and means the server won't send any data that the application has already received even if the application has been disconnected for an extended period of time.
 
-###Consistency
+### Consistency
 
 Some applications can only make decisions about the data they receive if they have a consistent view of the data in the database. DCP provides consistency through snapshots and allow applications know that they have seen all mutations in the database up to a certain sequence number.
 
-###Performance
+### Performance
 
 DCP provides high throughput and low latency by keeping all of the most recent data that needs to be replicated in memory. This means that most DCP connection will never have to read data off of disk.

--- a/documentation/dead-connections.md
+++ b/documentation/dead-connections.md
@@ -1,16 +1,16 @@
-#Dead Connection Detection
+# Dead Connection Detection
 
 Dead connections will be detected through the use of a noop command which will be scheduled at a given interval. The noop will be sent on a per-connection basis as opposed to being sent for each stream. Upon receiving a noop the Consumer should immediately respond with a noop response.
 
-####Enabling dead connection detection
+#### Enabling dead connection detection
 
 Dead connection detection is turned off by default and must be enabled by the Consumer. It is highly recommended that the Consumer enable dead connection detection if the Consumer is not on the same node as the Producer. To enable dead connection detection the Consumer must send two [Control](commands/control.md) messages. The first [Control](commands/control.md) message will contain the key set to *"enable_noop"* and the value set to *"true"*. The second control message should set the noop interval by setting the key to *"set_noop_interval"* and the value should be a number (in seconds) in string form. We recommend setting the noop interval to 120 seconds. If the recommended value is choosen then the value of this [Control](commands/control.md) message will be *"120"*.
 
-####Handling a noop message
+#### Handling a noop message
 
 When the Consumer receives a noop message it should immediately respond with a noop response. The Producer will expect a response when it sends the Consumer this message and if no response is received the Producer will disconnect its connection. The Producer will wait for a response for an amount of time equal to the noop interval.
 
-####Consumer dead connection detection
+#### Consumer dead connection detection
 
 The Consumer should assume the connection is dead if it has not seen any messages for 2 * noop_interval. If no messages are seen the the Consumer should disconnect its connection.
 

--- a/documentation/failure-scenarios.md
+++ b/documentation/failure-scenarios.md
@@ -1,4 +1,4 @@
-##Failure Scenarios
+## Failure Scenarios
 
 Failure scenarios are handled through the use of failover logs which are kept for all VBuckets no matter what state the VBucket might be in. A failover log consists of one or more entries and each entry contains a VBUcket UUID/High Seqno pair. Below is an example of a failover log.
 
@@ -8,7 +8,7 @@ Failure scenarios are handled through the use of failover logs which are kept fo
 
 In this document we will represent the VBucket UUID as a letter, but in practice the VBucket UUID will be represented as a random 64-bit value. The VBucket UUID can best be thought of as identifying a history of mutations. Every time the writer of the history changes we need to create a new failover log entry. We consider a change in history to occur whenever a VBucket changes it's state to active or whenever a node recovers from an unclean shutdown. When this happens an entry is created by generating a random VBucket UUID and associating it with the highest squence number contained in the VBucket.
 
-####Failover Log Behavior
+#### Failover Log Behavior
 
 In this section we will demonstrate how a failover log is used to deal with failure scenarios. Figure 1 shows the initial state of the cluster for this example failover scenario.
 
@@ -38,7 +38,7 @@ Since Node B and Node C each have items for history W Node B will need to rollba
 
 ![Figure 5](../images/upr_failover_log_5.jpg)
 
-####Failover Log (Handshake)
+#### Failover Log (Handshake)
 
 In typcal cases it is recommended that a DCP consumer just sends the latest VBucket UUID/High Seqno pair that they have in order to connect to a producer. The failover log will always be included in the OK response that is returned from the Stream Request command. This failover log should be persisted immediately after receiving the OK response. For more information on how this workflow takes place see the [UPR Session](upr-session.md) document.
 

--- a/documentation/flow-control.md
+++ b/documentation/flow-control.md
@@ -1,10 +1,10 @@
-#Flow Control
+# Flow Control
 
 In order to make sure that a Producer does not overload a Consumer with messages the DCP Protocol provides a flow control mechanism so that the Producer can control the amount of data that is sent to the Consumer. This flow control algorithm works by using a windowing mechanism where the window size is specified in bytes by the Consumer. Flow control will be available to the Consumer on both a per connection and a per stream basis. While it will be possible to use both mechanisms at the same time it is not recommended, due to the added complexity on the Consumer side.
 
 **Note:** Current versions of Couchbase only support connection based flow control.
 
-###High Level Flow Control Behavior
+### High Level Flow Control Behavior
 
 When a Consumer wants to use flow control it does so by specifing the buffer size it has available in bytes to the Producer. Specifying 0 indicates that flow control will not be used and that the Producer is free to send data to the Consumer as soon as the Producer can send it. If the Producer receives a non-zero buffer size then it will keep a series of stats to track how much data has been sent to the Consumer in order to control the amount of messages it sends. An example of a connection that is set up using flow control is below.
 
@@ -20,7 +20,7 @@ The Producer will then check to see if there is any room in the Consumers buffer
 
 ![Figure 1](../images/flow_control_4.jpg)
 
-###Per Connection Flow Control Example
+### Per Connection Flow Control Example
 
 1. The Consumer creates a connection with the Producer by sending an [Open Connection](commands/open-connection.md) message. To establish flow control the Consumer will then send a [Control](commands/control.md) message. This message should specify that the consumer wants to use a per connection buffer by specifying the parameter “connection_buffer_size” in the key section and the buffer size in the value section of the [Control](commands/control.md) message. In this example the buffer size will be 102400 (100KB).
 
@@ -36,7 +36,7 @@ The Producer will then check to see if there is any room in the Consumers buffer
 
 7. Steps 4-6 continue until the connection is closed.
 
-###Per Stream Flow Control Behavior
+### Per Stream Flow Control Behavior
 
 **Note:** Couchbase does not currently support stream based flow control
 
@@ -54,31 +54,31 @@ The Producer will then check to see if there is any room in the Consumers buffer
 
 7. Steps 4-6 continue until the connection is closed.
 
-###Consumer-Side Buffer Advertising
+### Consumer-Side Buffer Advertising
 
 The Producer will not specifically request [Buffer Acknowledgement](commands/buffer-ack.md) messages for any mutations or at any intervals of time. Decisions about when to send [Buffer Acknowledgement](commands/buffer-ack.md) messages is up to the Consumer. It is recommend however that Consumers send an acknowledgement after 50KB or 20% of the buffer has been processed.
 
-###Large items
+### Large items
 
 Couchbase allows a maximum data size of 20MB which means a client must be ready to receive an item of this size. Consumers will rarely want to keep stream buffers of this size since this would mean the application would need to reserve 20MB * 1024 Vbuckets or 20GB of buffer space if they stream all VBuckets. In order to deal with this issue Consumers must be aware that their code will need to be able to handle recieving items that will overflow their buffers. The Producer will continue to send items as long as there is any space available in the Consumers buffer no matter what the size of the item.
 
-###Setting 0 Buffer Size
+### Setting 0 Buffer Size
 
 Setting the buffer size for a stream to zero is a special case for flow control. This means that the connection or streams will not use any flow control.
 
-###Buffering Messages
+### Buffering Messages
 
 Only Mutation, Deletion, Expiration, Snapshot Markers, Set VBucket State, and Stream End messages should be buffered. All other messages should be processed immediately and should not be counted as taking up buffer space. This is important because DCP connections should always be able to process [No-op](commands/no-op.md) messages quickly. Other messages like [Control](commands/control.md) messages do not take up significant memory space and can be applied immediatley without having to take up buffer space.
 
-##Flow control policies in DCP Consumer (replica connection) on Couchbase Data Nodes
+## Flow control policies in DCP Consumer (replica connection) on Couchbase Data Nodes
 There are 4 different types are of flow control policies that are supported by DCP consumers on couchbase data nodes. They are **(1) none (2) static (3) dynamic (4) aggressive**. One of these policies can be chosen by setting it in the configuration file.  The DCP consumers on couchbase data nodes are created for data replication from active to replica vbuckets.
 
 Below is the description of each of the 4 policies:
-###None:
+### None:
 No flow control policy is adopted. Consumer will advertize the buffer size as 0 to the Producer.
-###Static
+### Static
 In this policy all flow control buffer sizes are fixed to a particular value. This value is a configurable. By default it is 10MB.
-###Dynamic
+### Dynamic
 In this policy flow control buffer sizes are set only once during the connection set up. It is set as a percentage (default 1) of bucket mem quota and also within max (default 50MB) and a min value (default 10 MB). Once dynamic flow control buffer memory usage goes beyond a threshold (10% of bucket memory), all subsequent connections get a flow control buffer size of min value (default 10MB)
-###Aggressive
+### Aggressive
 In this policy flow control buffer sizes are always set as a percentage (default 5%) of bucket memory quota across all flow control buffers, but within max (default 50MB) and a min value (default 10 MB). Every time a new connection is made or a disconnect happens, flow control buffer size of all other connections is changed to share an aggregate percentage(default 5%) of bucket memory

--- a/documentation/future-work.md
+++ b/documentation/future-work.md
@@ -1,17 +1,17 @@
-##Future Work
+## Future Work
 
-####Connection Filters
+#### Connection Filters
 
 We should be able to filter documents in order to allow a consumer to specify a stream where only documents matching a specific pattern are sent. Filters can be either a regex or some sort of plugable code mechanism. We should be able to filter on keys, values, meta data, and operation type.
 
-####Slow Connection Detection (Tentative for 3.1)
+#### Slow Connection Detection (Tentative for 3.1)
 
 We need to be able to deal with connections that do not read data quickly. Since we don't allow items in an in-memory checkpoint to be purged from memory if a cursor is registered a slow connection can cause high memory overhead in the server. One proposal for this is to drop the cursor from memory and close the stream forcing the client to reconnect the stream once it is ready to receive more items.
 
-####Connection Prioritization
+#### Connection Prioritization
 
 We need a way to specify that certain DCP connections should be visited and receive a higher priority than other connections. This will allow us to make sure replication is always getting the most attention, followed by xdcr and indexing, followed by backup/restore and other integration plugins.
 
-####Synchronous Replication
+#### Synchronous Replication
 
 We need to implement some sort of event notification system that will tell the producer when certain events have occurred on the consumer. These events for example could be item recieved (eg. replicated) and item persisted.

--- a/documentation/notifier-connection.md
+++ b/documentation/notifier-connection.md
@@ -1,5 +1,5 @@
 
-#Notifier Connection
+# Notifier Connection
 
 **Note** The notifier connection is intended for internal use only and may be removed at any time. It is currently considered deprecated.
 
@@ -7,7 +7,7 @@ In order to provide a Notification API, DCP implements a connection type called 
 
 To use the Notification API a Consumer will begin by creating a notifier connection. Since the Consumer knows the last sequence number it has received for each VBucket it can ask the server to notify it when new mutations are available by specifying the sequence number that the Consumer has last received as well as the corresponding VBucket ID. A notifier connection will never send items, but instead keep the stream open until a new item is received for that VBucket. When this happens the stream will be closed signifing to the Consumer that new items are ready to be streamed. The Consumer can then create a normal producer connection and request a stream containing the latest items.
 
-###Message Flow
+### Message Flow
 
 Below is a diagram and description of how a notifier connection can be used in order to receive notifications about items becoming ready for a specific VBucket.
 
@@ -25,7 +25,7 @@ Below is a diagram and description of how a notifier connection can be used in o
 
 6. Once a higher sequence number than the sequence number specified in the Start Sequence Number field is received for the VBucket the stream was created for the server will send the Consumer a [Stream End](commands/stream-end.md) message and close the stream. This [Stream End](commands/stream-end.md) message will indicate that new items are ready on the server.
 
-###Use Cases
+### Use Cases
 
 It is advised that applications which need to recieve a continuous stream of mutations leave their streams open indefinitely. This is achieved by setting the *End Sequence Number* field of a [Stream Request](commands/stream-request.md) to the maximum possible number. This is recommended because it will ensure that data is sent as soon as possible and won't add any overhead of frequently creating and destroying streams.
 

--- a/documentation/overview.md
+++ b/documentation/overview.md
@@ -1,18 +1,18 @@
-#Overview
+# Overview
 
-###Data Synchronization
+### Data Synchronization
 
 Data synchronization is an important part of any system that manages data, but its especially important in a distributed database. While a traditional databases rely on durability in order to prevent data loss during failures distributed databases rely on redundency of data by making sure that copies of the data are replicated to multiple servers. This allows a distributed system to prevent against against data loss in the face of node failures, rack failures and regional failures.
 
 The database is also the core of any datacenter deployment and the source of all information. The database however is typically not the only backend system in use and a data synchronization protocol is useful for keeping the data in all systems in the datacenter up to date with respect to the database. This is important both internally and externally to Couchbase. Internally Couchbase uses data synchronization to power its indexing, cross datacenter replication, and backup components. Externally the protocol can be used to move data into third-party systems such as Hadoop or ElasticSearch.
 
-###The Database Change Protocol
+### The Database Change Protocol
 
 The Database Change Protocol (DCP) is the data synchronization protocol used by Couchbase Server. It provides features and concepts that allow the development of rich and interesting features. DCP can be viewed as the heart of Couchbase because it pumps data to out to other components in the system so that they can function properly.
 
 DCP was developed from the ground up to quickly and efficiently move massive amounts of data around the cluster and datacenter. It provides guarentees of consistency so that applications that consume data with the DCP protocol can make sure that they are maing decisions based on a consistent view of the database. DCP also provides fine grained restartability in order to allow consumers of DCP to resume from exactly where they left off no matter how long they have been disconnected. Fine grained restartability is crucial when dealing with massive amounts of data because retrasmitting data that has already been sent may impose high costs. Finally DCP provides high throughput, low latency data transfer to allow applications to get the lastest data change as quickly as possible.
 
-###Intended Readers
+### Intended Readers
 
 The documentation contained on this website is written mainly for those interested in learning the in depth details of how the DCP protocol works in Couchbase or for developers who wish to build their own DCP Consumers to connect their third-party components to Couchbase.
 

--- a/documentation/protocol-flow.md
+++ b/documentation/protocol-flow.md
@@ -1,8 +1,8 @@
-##Protocol Flow
+## Protocol Flow
 
 This document intends to describe an example of the protocol flow between a Consumer and a Producer. The sections below will provide a step-by-step walk through of the messages exchanged by the Consumer and Producer for the lifetime of a connection.
 
-#####Creating the Connection
+##### Creating the Connection
 
 Creating a connection consists of opening a TCP/IP socket between the Consumer and the Producer and sending an [Open Connection](commands/open-connection.md) message. This [Open Connection](commands/open-connection.md) message message signifies this connection is a DCP connection and also allows the sender to give the connection a name. Below is a diagram of the interaction between the Producer and Consumer that takes place to establish a DCP connection.
 
@@ -14,7 +14,7 @@ Creating a connection consists of opening a TCP/IP socket between the Consumer a
 
 Once a DCP connection is created the Consumer can configure the connection by sending [Control](commands/control.md) messages to the Producer. [Control](commands/control.md) messages can be used to do things like enable [dead connection detection](dead-connections.md) and [flow control](flow-control.md). Sending [Control](commands/control.md) is not required if the default connection settings are sufficient.
 
-#####Starting the Stream
+##### Starting the Stream
 
 Once a connection has been created the Consumer can to create one or more VBucket Streams in order to stream data from Couchbase. The diagram below describes how to create a VBucket stream once a connection exists.
 
@@ -36,7 +36,7 @@ Once a connection has been created the Consumer can to create one or more VBucke
 
 Starting VBucket Streams can be parallelized since the Consumer can start as many streams as it needs to. Consumers should not create a connection per VBucket Stream since this will cause heavy resource usage on the server since each connection uses a file descriptor.
 
-#####Reading the Stream
+##### Reading the Stream
 
 Once a stream is started the Consumer will begin receiving data. The figure below shows what messages the Consumer should expect to receive. Fully understanding this section requires understanding what a [snapshot]() is and why snapshots are significant.
 
@@ -54,6 +54,6 @@ Once a stream is started the Consumer will begin receiving data. The figure belo
 4. At some point however the VBucket stream will be finished and the Producer will send a [Stream End](commands/stream-end.md) message to signify the stream is finished. A stream may end for different reasons so it is important to check the status code in the [Stream End](commands/stream-end.md) message.
 
 
-#####Closing a Connection
+##### Closing a Connection
 
 When the Consumer wants to end a DCP connection it should simply close the socket. The Producer will see the connection going down and this will cause the Producer to remove any structures used for sending data to the Consumer.

--- a/documentation/protocol.md
+++ b/documentation/protocol.md
@@ -1,5 +1,5 @@
 
-#Protocol Specification
+# Protocol Specification
 
 DCP utilizes the Memcached binary protocol as the basis for protocol definitions ([Memcached Binary Protocol Definitions](https://code.google.com/p/memcached/wiki/BinaryProtocolRevamped)) and defines a set opcodes for DCP commands.
 
@@ -7,7 +7,7 @@ A DCP connection differs from the standard Memcached connections because DCP con
 
 The typical scenario begins with the client requesting a stream. Upon success the server starts sending messages back to the client for mutations/deletions/expirations etc. While receiving messages the client can send additional commands to the server to start additional DCP streams, etc.
 
-###Protocol Definitions
+### Protocol Definitions
 
 * [**Open Connection**](commands/open-connection.md)
 * [**Add Stream**](commands/add-stream.md)

--- a/documentation/terminology.md
+++ b/documentation/terminology.md
@@ -1,4 +1,4 @@
-#Terminology
+# Terminology
 
 The purpose of this document is to provide definitions for common terms that are used throughout the DCP documentation.
 

--- a/documentation/upgrade.md
+++ b/documentation/upgrade.md
@@ -1,5 +1,5 @@
 
-#Upgrade (2.x to 3.x)
+# Upgrade (2.x to 3.x)
 
 Couchbase 3.x contains both the TAP and DCP protocols. As a result the cluster manager can choose to use either of the protocols for replication. In order to make things as simple as possible when upgrading the cluster manager only uses the TAP protocol when in a mixed cluster scenario (eg. during the upgrade). Once all nodes are running Couchbase 3.x the cluster manager will start closing TAP streams and replacing those closed streams with DCP streams. The cluster manager will continue to do this until the entire cluster is using the DCP protocol for replication.
 


### PR DESCRIPTION
Some time ago github revisited their markdown parser, and now it is
mandatory to put space after '#' sign to create a header.